### PR TITLE
fix: replace string in declare_id with ID from system_program

### DIFF
--- a/programs/solana-nft-anchor/src/lib.rs
+++ b/programs/solana-nft-anchor/src/lib.rs
@@ -13,7 +13,8 @@ use anchor_spl::{
 };
 use mpl_token_metadata::accounts::{ MasterEdition, Metadata as MetadataAccount };
 
-declare_id!("<UPDATE HERE>");
+
+declare_id!(anchor_lang::system_program::ID);
 #[program]
 pub mod solana_nft_anchor {
     use super::*;


### PR DESCRIPTION
The string in the declare_id ``` declare_id!("<UPDATE HERE>");```  does not pass the base58 encoding check, there by does not allow a successful build with anchor. if replaced with ```anchor_lang::system_program::ID```, the program compiles and builds successfully.